### PR TITLE
Add explicit documentation about proper PR merging to master

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,8 @@ Any final changes should be pushed to the release candidate prior to the Pull Re
 
 Upon merging of the release candidate branch into `master`, the merged feature branch Pull Requests will be automatically closed.
 
+> **Note**: You must perform a merge, not a squash squash and merge, otherwise Pull Requests will not be closed automatically.
+
 ### Tagging a release
 
 Once the release candidate is merged into `master`, a new release should be tagged matching the targeted release version.

--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,7 @@ Any final changes should be pushed to the release candidate prior to the Pull Re
 
 Upon merging of the release candidate branch into `master`, the merged feature branch Pull Requests will be automatically closed.
 
-> **Note**: You must perform a merge, not a squash squash and merge, otherwise Pull Requests will not be closed automatically.
+> **Note**: You must perform a merge, not a squash and merge, otherwise Pull Requests will not be closed automatically.
 
 ### Tagging a release
 


### PR DESCRIPTION
In order to actually automatically close PRs, explicitly document that you must use the merge not squash and merge option.
